### PR TITLE
docs: link to vercel configuration options when using a custom vercel.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Options:
 ```
 ## Using a custom `vercel.json` file
 
-If you want to add additional redirects or similar to your Vercel configuration you may want to provide a custom `vercel.json` file.
+If you want to add additional redirects or similar to your Vercel configuration you may want to provide a custom `vercel.json` file. A full list of options is [documented here](https://vercel.com/docs/project-configuration).
 
 To do this, first generate a configuration file (without running a deploy) using the `--generate-vercel-json` option:
 


### PR DESCRIPTION
## Motivation

- When reading the docs for the first time, I didn't know what options were assignable
- The default output on my device was overriding any the build/install commands specified in the Vercel UI, so it's useful to know how to override them.

## Related

- Came up while  figuring out how to set up a demo ( https://github.com/hydrosquall/datasette-nteract-data-explorer/issues/7 )