### PR TITLE
Update python version in vercel 

### DIFF
--- a/datasette_publish_vercel/__init__.py
+++ b/datasette_publish_vercel/__init__.py
@@ -216,7 +216,7 @@ def _publish_vercel(
         {
             "name": project,
             "version": 2,
-            "builds": [{"src": "index.py", "use": "@vercel/python@3.12"}],
+            "builds": [{"src": "index.py", "use": "@vercel/python@4.5.1"}],
             "routes": [{"src": "(.*)", "dest": "index.py"}],
         },
         indent=4,

--- a/datasette_publish_vercel/__init__.py
+++ b/datasette_publish_vercel/__init__.py
@@ -216,7 +216,7 @@ def _publish_vercel(
         {
             "name": project,
             "version": 2,
-            "builds": [{"src": "index.py", "use": "@vercel/python@3.0.7"}],
+            "builds": [{"src": "index.py", "use": "@vercel/python@3.12"}],
             "routes": [{"src": "(.*)", "dest": "index.py"}],
         },
         indent=4,


### PR DESCRIPTION
as current version is no longer supported. see: https://vercel.com/docs/functions/runtimes/python#python-version

actual versions: https://www.npmjs.com/package/@vercel/python?activeTab=versions


fixes: #67 